### PR TITLE
Fixing the functionality of the "on" keyword in device configuration setup

### DIFF
--- a/config/config.y
+++ b/config/config.y
@@ -733,16 +733,16 @@ int	newtype(char *tonid) {
 	if (last != -1) {
 		struct	dev_ent	*lptr = &dtypes[last];
 
-		strncpy(dptr->intr,	lptr->intr, 5);
-		strncpy(dptr->init,	lptr->init, 5);
-		strncpy(dptr->open,	lptr->open, 5);
-		strncpy(dptr->close,	lptr->close, 5);
-		strncpy(dptr->read,	lptr->read, 5);
-		strncpy(dptr->write,	lptr->write, 5);
-		strncpy(dptr->control,	lptr->control, 5);
-		strncpy(dptr->seek,	lptr->seek, 5);
-		strncpy(dptr->getc,	lptr->getc, 5);
-		strncpy(dptr->putc,	lptr->putc, 5);
+		strcpy(dptr->intr,	lptr->intr);
+		strcpy(dptr->init,	lptr->init);
+		strcpy(dptr->open,	lptr->open);
+		strcpy(dptr->close,	lptr->close);
+		strcpy(dptr->read,	lptr->read);
+		strcpy(dptr->write,	lptr->write);
+		strcpy(dptr->control,	lptr->control);
+		strcpy(dptr->seek,	lptr->seek);
+		strcpy(dptr->getc,	lptr->getc);
+		strcpy(dptr->putc,	lptr->putc);
 	}
 	return ntypes++;
 }

--- a/config/config.y
+++ b/config/config.y
@@ -103,6 +103,7 @@ char *devstab[] = {
 };
 
 char	saveattrid[MAXNAME];		/* Holds the IDENT from an attribute	*/
+char    devtypename[MAXNAME];
 
 /********************************************************************************/
 /*										*/
@@ -111,7 +112,6 @@ char	saveattrid[MAXNAME];		/* Holds the IDENT from an attribute	*/
 /********************************************************************************/
 
 void	addattr(int, int);
-int	addton(char *);
 int	config_atoi(char *, int);
 void	devisid(char *);
 void	devonid(char *);
@@ -119,6 +119,7 @@ void	getattrid(char *);
 void	newdev(char *);
 int	newtype(char *);
 void	yyerror(char *);
+void savename(char *);
 
 
 %}
@@ -146,7 +147,7 @@ devtypes:	/* nothing */ { doing = "device definitions"; }
 devtype:	tname COLON dev_tlist
 ;
 
-tname:		IDENT { $$ = newtype(yytext); }
+tname:		IDENT { savename(yytext); }
 ;
 
 dev_tlist:	theader attr_list
@@ -156,7 +157,7 @@ dev_tlist:	theader attr_list
 theader:	ON tonid { $$ = $2; }
 ;
 
-tonid:		IDENT { $$ = addton(yytext); }
+tonid:		IDENT { newtype(yytext); }
 ;
 
 attr_list:	/* nothing */
@@ -462,28 +463,6 @@ void	addattr(int tok, int val) {
 	}
 }
 
-
-/************************************************************************/
-/*									*/
-/* addton -- add an "on XXX" to the current type			*/
-/*									*/
-/************************************************************************/
-
-int	addton(char *tonid) {
-	int	currtype;		/* The current type		*/
-
-	if (strlen(tonid) >= MAXNAME) {
-		fprintf(stderr,"string %s is too long on line %d\n",
-				tonid, linectr);
-		exit(1);
-	}
-	currtype = ntypes - 1;
-	strcpy(dtypes[currtype].ison, tonid);
-
-	return currtype;
-}
-
-
 /************************************************************************/
 /*									*/
 /* config_atoi - convert an ascii string of text to an integer,		*/
@@ -674,14 +653,32 @@ void	newdev(char *name) {
 }
 
 
+
 /************************************************************************/
 /*									*/
-/* newtype -- allocate an entry in the type array and fill in the name	*/
+/* savename -- save the name of a new device type for use when making dentrys	*/
 /*									*/
 /************************************************************************/
 
-int	newtype(char *name) {
+void savename(char *name) {
+    if (strlen(name) >= MAXNAME) {
+		fprintf(stderr,"Type name %s is too long on line %d\n",
+				name, linectr);
+		exit(1);
+	}
+    strcpy(devtypename, name);
+}
 
+
+/************************************************************************/
+/*									*/
+/* newtype -- allocate an entry in the type array and fill in the name ison fields	*/
+/*									*/
+/************************************************************************/
+
+int	newtype(char *tonid) {
+
+    char *name = devtypename;
 	struct	dev_ent	*dptr;		/* Ptr. to an entry in dtypes	*/
 	int	i;			/* Index into the type table	*/
 
@@ -695,12 +692,18 @@ int	newtype(char *name) {
 		exit(1);
 	}
 
-	/* Verify that the type name is unique */
+    if (strlen(tonid) >= MAXNAME) {
+		fprintf(stderr,"string %s is too long on line %d\n",
+				tonid, linectr);
+		exit(1);
+	}
+
+	/* Verify that the (type name, is on) pair is unique */
 
 	for (i=0; i<ntypes; i++) {
-		if (strcmp(name, dtypes[i].tname) == 0) {
-			fprintf(stderr, "Duplicate type name %s on line %d\n",
-				name, linectr);
+		if (strcmp(name, dtypes[i].tname) == 0 && strcmp(tonid, dtypes[i].ison) == 0) {
+			fprintf(stderr, "Duplicate type name on line %d: %s on %s\n",
+				linectr, name, tonid);
 			exit(1);
 		}
 	}
@@ -711,6 +714,7 @@ int	newtype(char *name) {
 
 	bzero((void *)dptr, sizeof(struct dev_ent));
 	strcpy(dptr->tname,	 name);
+    strcpy(dptr->ison, tonid);
 	strncpy(dptr->intr,	"ioerr", 5);
 	strncpy(dptr->init,	"ioerr", 5);
 	strncpy(dptr->open,	"ioerr", 5);

--- a/config/config.y
+++ b/config/config.y
@@ -103,7 +103,7 @@ char *devstab[] = {
 };
 
 char	saveattrid[MAXNAME];		/* Holds the IDENT from an attribute	*/
-char    devtypename[MAXNAME];
+char	devtypename[MAXNAME];
 
 /********************************************************************************/
 /*										*/
@@ -572,7 +572,7 @@ void	devonid(char *onname) {
 	for (i=0; i<ntypes; i++) {
 		tptr = &dtypes[i];
 		if ( (strcmp(dptr->tname,tptr->tname) == 0 ) &&
-		     (strcmp(dptr->ison, tptr->ison)  == 0 )  ){
+			 (strcmp(dptr->ison, tptr->ison)  == 0 ) ){
 
 			/* The specified type matches the ith entry, so	*/
 			/*  set all attributes equal to the ones in the	*/
@@ -661,12 +661,12 @@ void	newdev(char *name) {
 /************************************************************************/
 
 void savename(char *name) {
-    if (strlen(name) >= MAXNAME) {
+	if (strlen(name) >= MAXNAME) {
 		fprintf(stderr,"Type name %s is too long on line %d\n",
 				name, linectr);
 		exit(1);
 	}
-    strcpy(devtypename, name);
+	strcpy(devtypename, name);
 }
 
 
@@ -678,9 +678,10 @@ void savename(char *name) {
 
 int	newtype(char *tonid) {
 
-    char *name = devtypename;
+	char *name = devtypename;
 	struct	dev_ent	*dptr;		/* Ptr. to an entry in dtypes	*/
 	int	i;			/* Index into the type table	*/
+	int last = -1;  /* The last entry in the type table with the same type name */
 
 	if (ntypes >= NTYPES) {
 		fprintf(stderr,"Too many types on line %d", linectr);
@@ -692,7 +693,7 @@ int	newtype(char *tonid) {
 		exit(1);
 	}
 
-    if (strlen(tonid) >= MAXNAME) {
+	if (strlen(tonid) >= MAXNAME) {
 		fprintf(stderr,"string %s is too long on line %d\n",
 				tonid, linectr);
 		exit(1);
@@ -701,10 +702,13 @@ int	newtype(char *tonid) {
 	/* Verify that the (type name, is on) pair is unique */
 
 	for (i=0; i<ntypes; i++) {
-		if (strcmp(name, dtypes[i].tname) == 0 && strcmp(tonid, dtypes[i].ison) == 0) {
+		if (strcmp(name, dtypes[i].tname) == 0) {
+			last = i;
+			if (strcmp(tonid, dtypes[i].ison) == 0) {
 			fprintf(stderr, "Duplicate type name on line %d: %s on %s\n",
 				linectr, name, tonid);
 			exit(1);
+			}
 		}
 	}
 
@@ -714,7 +718,7 @@ int	newtype(char *tonid) {
 
 	bzero((void *)dptr, sizeof(struct dev_ent));
 	strcpy(dptr->tname,	 name);
-    strcpy(dptr->ison, tonid);
+	strcpy(dptr->ison, tonid);
 	strncpy(dptr->intr,	"ioerr", 5);
 	strncpy(dptr->init,	"ioerr", 5);
 	strncpy(dptr->open,	"ioerr", 5);
@@ -726,6 +730,20 @@ int	newtype(char *tonid) {
 	strncpy(dptr->getc,	"ioerr", 5);
 	strncpy(dptr->putc,	"ioerr", 5);
 
+	if (last != -1) {
+		struct	dev_ent	*lptr = &dtypes[last];
+
+		strncpy(dptr->intr,	lptr->intr, 5);
+		strncpy(dptr->init,	lptr->init, 5);
+		strncpy(dptr->open,	lptr->open, 5);
+		strncpy(dptr->close,	lptr->close, 5);
+		strncpy(dptr->read,	lptr->read, 5);
+		strncpy(dptr->write,	lptr->write, 5);
+		strncpy(dptr->control,	lptr->control, 5);
+		strncpy(dptr->seek,	lptr->seek, 5);
+		strncpy(dptr->getc,	lptr->getc, 5);
+		strncpy(dptr->putc,	lptr->putc, 5);
+	}
 	return ntypes++;
 }
 


### PR DESCRIPTION
The config/DESCRIPTION file states that the "on" keyword is used to "allow a type name to have two implementations" on different hardware. However the parser does not actually support this functionality right now and instead just creates one implementation per type on whatever hardware is defined last in for that type in the config/Configuration file.

For example, if config/Configuration contains:

tty:
        on uart
                -i ttyinit      -o ionull       -c ionull
                -r ttyread      -g ttygetc      -p ttyputc
                -w ttywrite     -s ioerr        -n ttycontrol
                -intr ttyhandler
        on uart2
                -i tttyinit2      -o ionull       -c ionull
                -r ttyread      -g ttygetc      -p ttyputc2
                -w ttywrite     -s ioerr        -n ttycontrol
                -intr ttyhandler

Only a device type of tty on uart2 will be made. Definition of a device of type tty on uart will return an error as an illegal device specification due to the device type tty on uart not existing.

This pull request fixes this issue by modifying the parser config/config.y to define a new device type every time the on keyword is used instead of just once every time a type name is used. All ith hardware implementations after the first are also given the functions of the i-1th hardware implementation as default in order to absolve the designer from having to retype any shared functions for every implementation definition.